### PR TITLE
Add closure support to menus

### DIFF
--- a/src/Menu/Frameworks/Bootstrap.php
+++ b/src/Menu/Frameworks/Bootstrap.php
@@ -11,17 +11,23 @@ class Bootstrap extends AbstractMenu
     public $dropdowns = '';
     public $menuCount = 0;
 
-    public function add(array $options)
+    public function add($options, $bool = false)
     {
         $tmpmenu = '';
-        // die(var_dump($options));
+
         foreach ($options as $inner_text => $linkIconArray) {
+//            if($bool)
+//                dd($linkIconArray, is_object($linkIconArray[3]));
+
             if (is_array($linkIconArray) && !isset($linkIconArray['link']) && !isset($linkIconArray['icon'])) {
                 $tmpmenu .= $this->addDropdown($inner_text, $linkIconArray, ['submenu']);
-            } elseif (is_object($linkIconArray)) {
-                $tmpmenu .= $this->addDropdown($inner_text, (array) $linkIconArray, ['submenu']);
+            } elseif (is_object($linkIconArray) && ! is_callable($linkIconArray)) {
+                $tmpmenu .= $this->addDropdown($inner_text, (array)$linkIconArray, ['submenu']);
+            } elseif($linkIconArray instanceof \Closure){
+                $tmpmenu .= $this->add($linkIconArray());
             } else {
                 $tmpmenu .= $this->build($inner_text, $linkIconArray);
+
             }
         }
 
@@ -42,11 +48,12 @@ class Bootstrap extends AbstractMenu
     {
         $this->menu = '';
         $this->menu .= $this->add(config('kregel.menu.items'));
+//        dd(config('kregel.menu.login.sign-out'));
         if (config('kregel.menu.login.enabled')) {
             if (Auth::check()) {
-                $this->menu .= $this->add(config('kregel.menu.login.sign-out'));
+                $this->menu .= $this->add(config('kregel.menu.login.sign-out'), true);
             } else {
-                $this->menu .= $this->add(config('kregel.menu.login.sign-in'));
+                $this->menu .= $this->add(config('kregel.menu.login.sign-in'), true);
             }
         }
 

--- a/src/Menu/Frameworks/Bootstrap.php
+++ b/src/Menu/Frameworks/Bootstrap.php
@@ -11,13 +11,11 @@ class Bootstrap extends AbstractMenu
     public $dropdowns = '';
     public $menuCount = 0;
 
-    public function add($options, $bool = false)
+    public function add($options)
     {
         $tmpmenu = '';
 
         foreach ($options as $inner_text => $linkIconArray) {
-//            if($bool)
-//                dd($linkIconArray, is_object($linkIconArray[3]));
 
             if (is_array($linkIconArray) && !isset($linkIconArray['link']) && !isset($linkIconArray['icon'])) {
                 $tmpmenu .= $this->addDropdown($inner_text, $linkIconArray, ['submenu']);
@@ -51,9 +49,9 @@ class Bootstrap extends AbstractMenu
 //        dd(config('kregel.menu.login.sign-out'));
         if (config('kregel.menu.login.enabled')) {
             if (Auth::check()) {
-                $this->menu .= $this->add(config('kregel.menu.login.sign-out'), true);
+                $this->menu .= $this->add(config('kregel.menu.login.sign-out'));
             } else {
-                $this->menu .= $this->add(config('kregel.menu.login.sign-in'), true);
+                $this->menu .= $this->add(config('kregel.menu.login.sign-in'));
             }
         }
 

--- a/src/Menu/Frameworks/Materialize.php
+++ b/src/Menu/Frameworks/Materialize.php
@@ -11,15 +11,17 @@ class Materialize extends AbstractMenu
     public $dropdowns = '';
     public $menuCount = 0;
 
-    public function add(array $options)
+    public function add($options)
     {
         $tmpmenu = '';
-        // die(var_dump($options));
+
         foreach ($options as $inner_text => $linkIconArray) {
             if (is_array($linkIconArray) && !isset($linkIconArray['link']) && !isset($linkIconArray['icon'])) {
                 $tmpmenu .= $this->addDropdown($inner_text, $linkIconArray, ['submenu']);
-            } elseif (is_object($linkIconArray)) {
-                $tmpmenu .= $this->addDropdown($inner_text, (array) $linkIconArray, ['submenu']);
+            } elseif (is_object($linkIconArray) && !is_callable($linkIconArray)) {
+                $tmpmenu .= $this->addDropdown($inner_text, (array)$linkIconArray, ['submenu']);
+            } elseif ($linkIconArray instanceof \Closure) {
+                $tmpmenu .= $this->add($linkIconArray());
             } else {
                 $tmpmenu .= $this->build($inner_text, $linkIconArray);
             }
@@ -31,12 +33,12 @@ class Materialize extends AbstractMenu
     public function addDropdown($dropdown_name, $elements, $classes = [])
     {
         ++$this->menuCount;
-        $this->dropdowns .= '<ul class="dropdown-content" id="dropdown-'.$this->menuCount.'">
-            '.$this->add($elements).'
+        $this->dropdowns .= '<ul class="dropdown-content" id="dropdown-' . $this->menuCount . '">
+            ' . $this->add($elements) . '
         </ul>';
 
-        return '<li class="'.implode(' ', $classes).'">
-            <a href="#" class="dropdown-button" data-activates="dropdown-'.$this->menuCount.'" role="button" aria-haspopup="true" aria-expanded="false">'.$dropdown_name.' <i class="material-icons right">arrow_drop_down</i></a>
+        return '<li class="' . implode(' ', $classes) . '">
+            <a href="#" class="dropdown-button" data-activates="dropdown-' . $this->menuCount . '" role="button" aria-haspopup="true" aria-expanded="false">' . $dropdown_name . ' <i class="material-icons right">arrow_drop_down</i></a>
         </li>';
     }
 
@@ -77,9 +79,9 @@ class Materialize extends AbstractMenu
         }
 
         return '<li>
-                <a '.$this->attributes(['href' => $this->linkBuilder($menu['link']), $attributes]).'>
-               '.(!empty($icon) ? '<i '.$this->attributes(['class' => $icon]).'></i>
-                &nbsp;' : '').$item_name.'
+                <a ' . $this->attributes(['href' => $this->linkBuilder($menu['link']), $attributes]) . '>
+               ' . (!empty($icon) ? '<i ' . $this->attributes(['class' => $icon]) . '></i>
+                &nbsp;' : '') . $item_name . '
               </a>
             </li>
         ';

--- a/src/Menu/Interfaces/AbstractMenu.php
+++ b/src/Menu/Interfaces/AbstractMenu.php
@@ -19,7 +19,7 @@ abstract class AbstractMenu
      *
      * @param array $options Should be some kind of array/key pair
      */
-    abstract public function add(array $options);
+    abstract public function add($options);
 
     /**
      * This function will be used when you try to build an element


### PR DESCRIPTION
I added support for the 'items' array to accept a closure.  I tried to use just the closure without editing your code, but php gave me a segmentation fault.

```
'items' => [
    // This menu will be shown regardless of whether or not
    // the login system is enabled!
    function() {
        if(auth()->user()->hasRole('developer')) 
        {
             return ['Admin Stuff' => ['link' =>'some/cool/route', 'icon' => 'fa fa-user']];
        }
    },
    'Like Things?' => [
        'link' => '#',
        'icon' => 'fa fa-line-chart',
    ],
],
```
